### PR TITLE
Fix SublimeLinter errors to work with the last version of SL

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,6 @@ import string
 class Norminette(Linter):
     """Provides an interface to norminette."""
 
-    syntax = 'c'
     executable = 'norminette'
 
     regex = r'''(?xi)
@@ -35,8 +34,9 @@ class Norminette(Linter):
     line_col_base = (1, 0)
     multiline = True
     error_stream = util.STREAM_BOTH
-    selectors = {}
-    defaults = {}
+    defaults = {
+        'selector': 'source.c'
+    }
 
     def split_match(self, match):
 


### PR DESCRIPTION
Thanks for your work, it is great !

I made a 2021 update to work with the last version of SublimeLinter. To prevent this error : 

 - Defining 'cls.selectors' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.
 - Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.