### PR TITLE
Improve error message regex

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -29,6 +29,7 @@ class Norminette(Linter):
         # part is optional.
         (?:(.+?(?P<line>\d+)))?
         (?:(.+?(?P<col>\d+)))?
+        (?:\)\:\s*)?
         (?:(?P<message>.+))
     '''
     


### PR DESCRIPTION
We get: `Error - Empty line at end of file`
Instead of: `Error - ):	Empty line at end of file`

Screenshot of the change:
![Screen Shot 2021-10-19 at 11 21 46 AM](https://user-images.githubusercontent.com/92152391/137881740-5c3570c7-597d-49cc-91f7-36507c74e576.png)
 
