### PR TITLE
Convert Norminette col to string/line index

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -42,6 +42,16 @@ class Norminette(Linter):
 
         match, line, col, error, warning, message, near = super().split_match(match)
 
+        if col > 0:
+            col -= 1
+            point = self.view.text_point(line, 0)
+            content = self.view.substr(self.view.line(point))
+            c = 0
+            while c < col and c < len(content):
+                if content[c] == '\t':
+                    col -= 3
+                c += 1
+
         if line is None and message:
             line = 0
             col = 0


### PR DESCRIPTION
Tabs are count like 4 in column index, then each time I found a tab before the col index I do -3 to convert col index to string index.

**After :**
![image](https://user-images.githubusercontent.com/92152391/138586460-bb8d2e52-86ea-4be8-84cb-de3cbd25cdc2.png)


**Before :**
![image](https://user-images.githubusercontent.com/92152391/138586482-d5d4fe42-aedd-43b6-83fa-1d824b72abae.png)

**Norminette output :**
```
srcs/ft_strmapi.c: Error!
Error: SPACE_BEFORE_FUNC    (line:  13, col:   5):	space before function name
Error: SPACE_REPLACE_TAB    (line:  15, col:   8):	Found space when expecting tab
Error: CONSECUTIVE_NEWLINES (line:  17, col:   1):	Consecutive newlines
Error: EMPTY_LINE_FUNCTION  (line:  17, col:   1):	Empty line in function
Error: CONSECUTIVE_NEWLINES (line:  18, col:   1):	Consecutive newlines
Error: EMPTY_LINE_FUNCTION  (line:  18, col:   1):	Empty line in function
Error: SPACE_EMPTY_LINE     (line:  18, col:   1):	Space on empty line
Error: IMPLICIT_VAR_TYPE    (line:  19, col:   1):	Missing type in variable declaration
Error: TOO_MANY_TAB         (line:  19, col:   1):	Extra tabs for indent level
Error: VAR_DECL_START_FUNC  (line:  19, col:   1):	Variable declaration not at start of function
Error: MISALIGNED_VAR_DECL  (line:  19, col:  13):	Misaligned variable declaration
Error: CONSECUTIVE_NEWLINES (line:  20, col:   1):	Consecutive newlines
Error: EMPTY_LINE_FUNCTION  (line:  20, col:   1):	Empty line in function
Error: SPACE_EMPTY_LINE     (line:  20, col:   1):	Space on empty line
```
