### PR TITLE
Refactor post-processing the linter result

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -15,6 +15,7 @@ from SublimeLinter.lint import Linter, persist, util
 import sublime
 import os
 import string
+import math
 
 class Norminette(Linter):
     """Provides an interface to norminette."""
@@ -48,8 +49,16 @@ class Norminette(Linter):
 
     def reposition_match(self, line, col, m, vv):
         if col > 0:
-            text = vv.select_line(line)
-            col -= text[:col].count("\t") * 3
+            content = vv.select_line(line)
+            c = 0
+            cr = 0
+            while c < col and c < len(content):
+                if content[c] == '\t':
+                    col -= 3 - (math.ceil(cr / 4) * 4 - cr)
+                    cr += 3
+                c += 1
+                cr += 1
+
         return super().reposition_match(line, col, m, vv)
 
     def cmd(self):


### PR DESCRIPTION
I can't use the linter and test this but probably this is what you want to do without accessing the view.

Use `reposition_match` to fix or recompute the `col` the linter outputs.  By doing so we avoid accessing the buffer
which is a mutable, live object and thus a side-effect.  Note that assuming a tab-size of 4 is still idiosyncratic.

Simplify `split_match` to fill in the required `line` information for unspecific errors.